### PR TITLE
Renaming transmission rate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     container: 
       image: gvegayon/epiworldrshiny:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Deploy
         env:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -36,7 +36,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -69,7 +69,7 @@ jobs:
           error-on: '"warning"'
 
       # Upload the built package as an artifact
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ matrix.config.os == 'ubuntu-latest' && matrix.config.r == 'release' }}
         with:
           name: ${{ matrix.config.os }}-pkg

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,13 @@
 Package: epiworldRShiny
 Type: Package
 Title: A 'shiny' Wrapper of the R Package 'epiworldR'
-Version: 0.1-0
-Date: 2024-05-31
+Version: 0.1-1
+Date: 2025-01-30
 Authors@R: c(
-  person("Derek", "Meyer", role=c("aut","cre"), 
-  email="derekmeyer37@gmail.com", comment = c(ORCID = "0009-0005-1350-6988")),
   person("George", "Vega Yon", role=c("aut"),
   email="g.vegayon@gmail.com", comment = c(ORCID = "0000-0002-3171-0844")),
+  person("Derek", "Meyer", role=c("aut","cre"), 
+  email="derekmeyer37@gmail.com", comment = c(ORCID = "0009-0005-1350-6988")),
   person("Centers for Disease Control and Prevention", role="fnd", comment = "Award number 1U01CK000585; 75D30121F00003"
   ),
   person("Lindsay", "Keegan", role=c("ctb"), email="lindsay.keegan@utah.edu", comment = c(ORCID = "0000-0002-8526-3007")),

--- a/epiworldRShiny.Rproj
+++ b/epiworldRShiny.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 5055a649-3f0d-46ac-8589-e770512cfa8d
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/inst/models/shiny_seir.R
+++ b/inst/models/shiny_seir.R
@@ -82,7 +82,7 @@ seir_panel <- function(model_alt) {
     condition = sprintf("input.model == '%s'", model_alt),
     text_input_disease_name("seir"),
     slider_prevalence("seir"),
-    slider_input_rate("seir", "Probability of exposure (daily)", "0.05", input_label = "transmission_rate"),
+    slider_input_rate("seir", "Transmission probability", "0.05", input_label = "transmission_rate"),
     slider_input_rate("seir", "Recovery probability (daily)", "0.14", input_label = "recovery_rate"),
     shiny::numericInput(
       inputId = "seir_incubation_days",

--- a/inst/models/shiny_seir.md
+++ b/inst/models/shiny_seir.md
@@ -8,7 +8,7 @@ The SEIR model has the following parameters:
 
 - **Disease Name**: The name of the disease being modeled.
 - **% of Population Infected**: The percentage of the population that is infected at the start of the simulation.
-- **Probability of exposure (daily)**: The probability that an individual will be exposed to the virus on a given day.
+- **Transmission probability**: Probability of becoming infected (or exposed, depending on the model) when interacting with an infectious agent.
 - **Recovery probability (daily)**: The probability that an individual will recover from the virus on a given day.
 - **Incubation Days**: The number of days that an individual is in the exposed state before becoming infectious.
 - **Simulation Time (Days)**: The number of days to simulate.

--- a/inst/models/shiny_seirconn.R
+++ b/inst/models/shiny_seirconn.R
@@ -52,7 +52,7 @@ seirconn_panel <- function(model_alt) {
     condition = sprintf("input.model == '%s'", model_alt),
     text_input_disease_name("seirconn"),
     slider_prevalence("seirconn"),
-    slider_input_rate("seirconn", "Probability of exposure (daily)", 0.1, input_label = "transmission_rate"),
+    slider_input_rate("seirconn", "Transmission probability", 0.1, input_label = "transmission_rate"),
     slider_input_rate("seirconn", "Recovery probability (daily)", 0.14, input_label = "recovery_rate"),
     slider_input_rate("seirconn", "Contact Rate", 4, maxval = 20),
     shiny::numericInput(

--- a/inst/models/shiny_seirconn.md
+++ b/inst/models/shiny_seirconn.md
@@ -8,7 +8,7 @@ The SEIR model has the following parameters:
 
 - **Disease Name**: The name of the disease being modeled.
 - **% of Population Infected**: The percentage of the population that is infected at the start of the simulation.
-- **Probability of exposure (daily)**: The probability that an individual will be exposed to the virus on a given day.
+- **Transmission probability**: Probability of becoming infected (or exposed, depending on the model) when interacting with an infectious agent.
 - **Recovery probability (daily)**: The probability that an individual will recover from the virus on a given day.
 - **Incubation Days**: The number of days that an individual is in the exposed state before becoming infectious.
 - **Contact rate**: The number of average contacts that an individual has per day.

--- a/inst/models/shiny_seirconnequity.R
+++ b/inst/models/shiny_seirconnequity.R
@@ -171,7 +171,7 @@ seirconnequity_panel <- function(model_alt) {
     condition = sprintf("input.model == '%s'", model_alt),
     text_input_disease_name("seirconnequity"),
     slider_prevalence("seirconnequity"),
-    slider_input_rate("seirconnequity", "Probability of exposure (daily)", 0.05, input_label = "transmission_rate"),
+    slider_input_rate("seirconnequity", "Transmission probability", 0.05, input_label = "transmission_rate"),
     slider_input_rate("seirconnequity", "Recovery probability (daily)", 0.14, input_label = "recovery_rate"),
     slider_input_rate("seirconnequity", "Contact Rate", 4, maxval = 20),
     shiny::numericInput(

--- a/inst/models/shiny_seirconnequity.md
+++ b/inst/models/shiny_seirconnequity.md
@@ -8,7 +8,7 @@ The SEIR model has the following parameters:
 
 - **Disease Name**: The name of the disease being modeled.
 - **% of Population Infected**: The percentage of the population that is infected at the start of the simulation.
-- **Probability of exposure (daily)**: The probability that an individual will be exposed to the virus on a given day.
+- **Transmission probability**: Probability of becoming infected (or exposed, depending on the model) when interacting with an infectious agent.
 - **Recovery probability (daily)**: The probability that an individual will recover from the virus on a given day.
 - **Incubation Days**: The number of days that an individual is in the exposed state before becoming infectious.
 - **Simulation Time (Days)**: The number of days to simulate.

--- a/inst/models/shiny_seird.R
+++ b/inst/models/shiny_seird.R
@@ -75,7 +75,7 @@ seird_panel <- function(model_alt) {
     condition = sprintf("input.model == '%s'", model_alt),
     text_input_disease_name("seird"),
     slider_prevalence("seird"),
-    slider_input_rate("seird", "Probability of exposure (daily)", "0.05", input_label = "transmission_rate"),
+    slider_input_rate("seird", "Transmission probability", "0.05", input_label = "transmission_rate"),
     slider_input_rate("seird", "Recovery probability (daily)", "0.14", input_label = "recovery_rate"),
     slider_input_rate("seird", "Probability of death (daily)", 0.01, input_label = "death_rate"),
     shiny::numericInput(

--- a/inst/models/shiny_seird.md
+++ b/inst/models/shiny_seird.md
@@ -8,7 +8,7 @@ The SEIRD model has the following parameters:
 
 - **Disease Name**: The name of the disease being modeled.
 - **% of Population Infected**: The percentage of the population that is infected at the start of the simulation.
-- **Probability of exposure (daily)**: The probability that an individual will be exposed to the virus on a given day.
+- **Transmission probability**: Probability of becoming infected (or exposed, depending on the model) when interacting with an infectious agent.
 - **Recovery probability (daily)**: The probability that an individual will recover from the virus on a given day.
 - **Incubation Days**: The number of days that an individual is in the exposed state before becoming infectious.
 - **Death probability (daily)**: The probability that an individual will die from the virus on a given day.

--- a/inst/models/shiny_sir.R
+++ b/inst/models/shiny_sir.R
@@ -60,7 +60,7 @@ sir_panel <- function(model_alt) {
     condition = sprintf("input.model == '%s'", model_alt),
     text_input_disease_name("sir"),
     slider_prevalence("sir"),
-    slider_input_rate("sir", "Probability of exposure (daily)", "0.05", input_label = "transmission_rate"),
+    slider_input_rate("sir", "Transmission probability", "0.05", input_label = "transmission_rate"),
     slider_input_rate("sir", "Recovery probability (daily)", "0.14", input_label = "recovery_rate"),
     numeric_input_ndays("sir"),
     seed_input("sir"),

--- a/inst/models/shiny_sir.md
+++ b/inst/models/shiny_sir.md
@@ -8,7 +8,7 @@ The SIR model has the following parameters:
 
 - **Disease Name**: The name of the disease being modeled.
 - **% of Population Infected**: The percentage of the population that is infected at the start of the simulation.
-- **Probability of exposure (daily)**: The probability that an individual will be exposed to the virus on a given day.
+- **Transmission probability**: Probability of becoming infected (or exposed, depending on the model) when interacting with an infectious agent.
 - **Recovery probability (daily)**: The probability that an individual will recover from the virus on a given day.
 - **Simulation Time (Days)**: The number of days to simulate.
 - **Seed**: The seed for the random number generator.

--- a/inst/models/shiny_sirconn.R
+++ b/inst/models/shiny_sirconn.R
@@ -51,7 +51,7 @@ sirconn_panel <- function(model_alt) {
     condition = sprintf("input.model == '%s'", model_alt),
     text_input_disease_name("sirconn"),
     slider_prevalence("sirconn"),
-    slider_input_rate("sirconn", "Probability of exposure (daily)", 0.1, input_label = "transmission_rate"),
+    slider_input_rate("sirconn", "Transmission probability", 0.1, input_label = "transmission_rate"),
     slider_input_rate("sirconn", "Recovery probability (daily)", 0.14, input_label = "recovery_rate"),
     slider_input_rate("sirconn", "Contact Rate", 4, maxval = 20),
     shiny::sliderInput(

--- a/inst/models/shiny_sirconn.md
+++ b/inst/models/shiny_sirconn.md
@@ -8,7 +8,7 @@ The SIR model has the following parameters:
 
 - **Disease Name**: The name of the disease being modeled.
 - **% of Population Infected**: The percentage of the population that is infected at the start of the simulation.
-- **Probability of exposure (daily)**: The probability that an individual will be exposed to the virus on a given day.
+- **Transmission probability**: Probability of becoming infected (or exposed, depending on the model) when interacting with an infectious agent.
 - **Recovery probability (daily)**: The probability that an individual will recover from the virus on a given day.
 - **Contact rate**: The number of average contacts that an individual has per day.
 - **Simulation Time (Days)**: The number of days to simulate.

--- a/inst/models/shiny_sird.R
+++ b/inst/models/shiny_sird.R
@@ -62,7 +62,7 @@ sird_panel <- function(model_alt) {
     condition = sprintf("input.model == '%s'", model_alt),
     text_input_disease_name("sird"),
     slider_prevalence("sird"),
-    slider_input_rate("sird", "Probability of exposure (daily)", 0.05, input_label = "transmission_rate"),
+    slider_input_rate("sird", "Transmission probability", 0.05, input_label = "transmission_rate"),
     slider_input_rate("sird", "Recovery probability (daily)", 0.14, input_label = "recovery_rate"),
     slider_input_rate("sird", "Probability of death (daily)", 0.01, input_label = "death_rate"),
     numeric_input_ndays("sird"),

--- a/inst/models/shiny_sird.md
+++ b/inst/models/shiny_sird.md
@@ -8,7 +8,7 @@ The SIRD model has the following parameters:
 
 - **Disease Name**: The name of the disease being modeled.
 - **% of Population Infected**: The percentage of the population that is infected at the start of the simulation.
-- **Probability of exposure (daily)**: The probability that an individual will be exposed to the virus on a given day.
+- **Transmission probability**: Probability of becoming infected (or exposed, depending on the model) when interacting with an infectious agent.
 - **Recovery probability (daily)**: The probability that an individual will recover from the virus on a given day.
 - **Death probability (daily)**: The probability that an individual will die from the virus on a given day.
 - **Simulation Time (Days)**: The number of days to simulate.

--- a/inst/models/shiny_sis.R
+++ b/inst/models/shiny_sis.R
@@ -74,7 +74,7 @@ sis_panel <- function(model_alt) {
     condition = sprintf("input.model == '%s'", model_alt),
     text_input_disease_name("sis"),
     slider_prevalence("sis"),
-    slider_input_rate("sis", "Probability of exposure (daily)", 0.05, input_label = "transmission_rate"),
+    slider_input_rate("sis", "Transmission probability", 0.05, input_label = "transmission_rate"),
     slider_input_rate("sis", "Recovery probability (daily)", 0.14, input_label = "recovery_rate"),
     numeric_input_ndays("sis"),
     seed_input("sis"),

--- a/inst/models/shiny_sis.md
+++ b/inst/models/shiny_sis.md
@@ -8,7 +8,7 @@ The SIS model has the following parameters:
 
 - **Disease Name**: The name of the disease being modeled.
 - **% of Population Infected**: The percentage of the population that is infected at the start of the simulation.
-- **Probability of exposure (daily)**: The probability that an individual will be exposed to the virus on a given day.
+- **Transmission probability**: Probability of becoming infected (or exposed, depending on the model) when interacting with an infectious agent.
 - **Recovery probability (daily)**: The probability that an individual will recover from the virus on a given day.
 - **Simulation Time (Days)**: The number of days to simulate.
 - **Seed**: The seed for the random number generator.

--- a/inst/models/shiny_sisd.R
+++ b/inst/models/shiny_sisd.R
@@ -62,7 +62,7 @@ sisd_panel <- function(model_alt) {
     condition = sprintf("input.model == '%s'", model_alt),
     text_input_disease_name("sisd"),
     slider_prevalence("sisd"),
-    slider_input_rate("sisd", "Probability of exposure (daily)", 0.05, input_label = "transmission_rate"),
+    slider_input_rate("sisd", "Transmission probability", 0.05, input_label = "transmission_rate"),
     slider_input_rate("sisd", "Recovery probability (daily)", 0.14, input_label = "recovery_rate"),
     slider_input_rate("sisd", "Death Rate", "0.01"),
     numeric_input_ndays("sisd"),

--- a/inst/models/shiny_sisd.md
+++ b/inst/models/shiny_sisd.md
@@ -8,7 +8,7 @@ The SISD model has the following parameters:
 
 - **Disease Name**: The name of the disease being modeled.
 - **% of Population Infected**: The percentage of the population that is infected at the start of the simulation.
-- **Probability of exposure (daily)**: The probability that an individual will be exposed to the virus on a given day.
+- **Transmission probability**: Probability of becoming infected (or exposed, depending on the model) when interacting with an infectious agent.
 - **Recovery probability (daily)**: The probability that an individual will recover from the virus on a given day.
 - **Death probability (daily)**: The probability that an individual will die from the virus on a given day.
 - **Simulation Time (Days)**: The number of days to simulate.


### PR DESCRIPTION
This pull request includes several updates to the `epiworldRShiny` package, focusing on standardizing terminology and updating package metadata. The most important changes are the renaming of "Probability of exposure (daily)" to "Transmission probability" across multiple files and the update of the package version and date in the `DESCRIPTION` file.

Metadata and Configuration Updates:
* [`DESCRIPTION`](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL4-R10): Updated package version to `0.1-1` and date to `2025-01-30`. Reordered authors to maintain alphabetical order.
* [`epiworldRShiny.Rproj`](diffhunk://#diff-f50c26f8e8f1c7f957c97aa939ae8c714b26dc138c78fbdd8d40c199f7d4e901R2): Added `ProjectId` to the project configuration.

Terminology Standardization:
* `inst/models/shiny_seir.R`, `inst/models/shiny_seirconn.R`, `inst/models/shiny_seirconnequity.R`, `inst/models/shiny_seird.R`, `inst/models/shiny_sir.R`, `inst/models/shiny_sirconn.R`, `inst/models/shiny_sird.R`, `inst/models/shiny_sis.R`, `inst/models/shiny_sisd.R`: Renamed "Probability of exposure (daily)" to "Transmission probability" in the slider input parameters. [[1]](diffhunk://#diff-57bd98f514b17cf5b79048ee54b38ce243f42fde83096c10ccb5243e20843414L85-R85) [[2]](diffhunk://#diff-4d2375ddd0ab996b875b26aa99fd27a851285a964f177de9e4ccea9619422e7cL55-R55) [[3]](diffhunk://#diff-44e092b213a2a9d25ec831af259579f7595d4b695fe365fd36485fd1f83ebc23L174-R174) [[4]](diffhunk://#diff-e5ff1935c85a470e952347dd8c7f84025ef905c921894763f30496c245678d66L78-R78) [[5]](diffhunk://#diff-97d60d47a1d8d5524eb6f9383e4a9264d5e4081e8bfd5b5570d01b55016ce84eL63-R63) [[6]](diffhunk://#diff-39d757e3445bfe15d0149425f2a16eb26c592ef1d558a6e7b1493114f2841a8bL54-R54) [[7]](diffhunk://#diff-d37b73fbcc80fd2528d21a71ffcd74738889e81f5ded9bc819af6e506a405f64L65-R65) [[8]](diffhunk://#diff-f414d5983d27b599699710e396ea9efd37e0eb34cb68e39d0c38d093a8c75009L77-R77) [[9]](diffhunk://#diff-c12cd7a7d7bdf91decab9c2aaa4cc1faafb3a03e59b9fa9eb4c162af64ea7432L65-R65)
* `inst/models/shiny_seir.md`, `inst/models/shiny_seirconn.md`, `inst/models/shiny_seirconnequity.md`, `inst/models/shiny_seird.md`, `inst/models/shiny_sir.md`, `inst/models/shiny_sirconn.md`, `inst/models/shiny_sird.md`, `inst/models/shiny_sis.md`, `inst/models/shiny_sisd.md`: Updated documentation to reflect the change from "Probability of exposure (daily)" to "Transmission probability". [[1]](diffhunk://#diff-59caa30d4c7531b0a23b1873a00f2566480e506cbbfcbd24f1be01b4a1aec255L11-R11) [[2]](diffhunk://#diff-f5e7e14c2c34d1ab0b11aef04e47f1fc274c4dcf6320d13fbc885e18d773d2d1L11-R11) [[3]](diffhunk://#diff-a273c39735a29f7a19ea2acd0e7eb56c3ab71b3ed06b672100360f16f250f970L11-R11) [[4]](diffhunk://#diff-637b090f3b00e3cbc3580db40b1b0849e4d4261621509a49da85cbce41c02dc6L11-R11) [[5]](diffhunk://#diff-249fbaa111bf0bed3aa93f79b47ee61684b4eb9eeb577670ebd9dada65316ac0L11-R11) [[6]](diffhunk://#diff-08c6535d32a13f44aa6296f565e45188eb1822bf223e5fcc68f425e33b9a7d58L11-R11) [[7]](diffhunk://#diff-881cbdb66411d8574d1d99a67d0af3761e493e71d15234a52ed11b5fbbef24c2L11-R11) [[8]](diffhunk://#diff-3d9b1d2f3c92af774f7159549a21a2a722c43455f86e1c114b850b8c1b3f64ffL11-R11) [[9]](diffhunk://#diff-b303ff7e997080f3d19e27481bf3d8de2f7afde732892344b7729c3d7694b2faL11-R11)