### PR TITLE
Fixing broken GitHub link

### DIFF
--- a/inst/models/shiny_measles.md
+++ b/inst/models/shiny_measles.md
@@ -2,7 +2,7 @@
     <strong>Warning:</strong> This is work in progress. The model does
     not include post-exposure prophylaxis or community transmission.
     We would love to hear your feedback on the model. All the source
-    code is available <a href="https://github.com/UofUEpiBio/epiworldRShiny/tree/measlesquarantine">here</a>.
+    code is available <a href="https://github.com/UofUEpiBio/epiworldRShiny">here</a>.
 </div>
 
 # Modeling Measles in Schools


### PR DESCRIPTION
The summary `card()` in the "Measles in Schools" model's UI panel has a warning box at the top that uses [this link to the `measlesquarantine` branch of this repo](https://github.com/UofUEpiBio/epiworldRShiny/tree/measlesquarantine). I got a 404 when I followed this link, but I gathered that I was supposed to be directed to just the landing page of this repo, so I changed it to direct to [the default branch version of this repo](https://github.com/UofUEpiBio/epiworldRShiny).

Thanks for your work on this wonderful tool!